### PR TITLE
Fix SIB no-base handling when REX.B is set

### DIFF
--- a/cpueaxh/cpu/helper.hpp
+++ b/cpueaxh/cpu/helper.hpp
@@ -275,7 +275,7 @@ uint64_t get_effective_offset(CPU_CONTEXT* ctx, uint8_t modrm, uint8_t* sib, int
             }
 
             bool has_index = !(raw_index == 4 && !(long_mode && ctx->rex_x));
-            bool no_base = (mod == 0 && raw_base == 5 && !(long_mode && ctx->rex_b));
+            bool no_base = (mod == 0 && raw_base == 5);
 
             if (no_base) {
                 addr = (uint32_t)(*disp);

--- a/cpueaxh/instructions/lea.hpp
+++ b/cpueaxh/instructions/lea.hpp
@@ -45,7 +45,7 @@ uint64_t calculate_lea_address(CPU_CONTEXT* ctx, uint8_t modrm, bool has_sib, ui
             }
 
             bool has_index = !(raw_index == 4 && !(long_mode_addr && ctx->rex_x));
-            bool no_base = (mod == 0 && raw_base == 5 && !(long_mode_addr && ctx->rex_b));
+            bool no_base = (mod == 0 && raw_base == 5);
 
             if (no_base) {
                 if (address_size == 64) {


### PR DESCRIPTION
## Fix incorrect SIB no-base handling when REX.B is set

This change fixes incorrect handling of the SIB no-base special form in 64-bit mode.

In x86-64, when a memory operand uses a SIB byte and the encoding satisfies:

- `mod = 00`
- `SIB.base = 101b`

the address form is **disp32-only**, meaning the effective address is taken from the 32-bit displacement and **no base register is used**.

This special rule still applies when `REX.B = 1`.

The current implementation incorrectly treats `REX.B` as disabling the no-base special case. As a result, instructions that should use `[disp32]` are instead interpreted as if they used `R13` as a base register.

### Observable misbehavior

For example, the instruction bytes:

```asm
49 8B 04 25 00 00 05 00
```

should decode as:

```asm
mov rax, qword ptr [0x50000]
```

However, the current implementation may treat it as if the effective address were based on `R13`, because:

- `raw_base = 101b`
- `REX.B = 1`
- the current code incorrectly rejects the no-base path
- the base field is then extended to register 13 (`R13`)

This causes the effective address calculation to use `R13` instead of the displacement-only form required by the ISA. As a result, it will be decoded as:

```asm
mov rax, qword ptr [r13]
```

### Affected paths

The same logic error exists in two places:

- helper.hpp
- lea.hpp

That means both normal memory operands and `LEA` are affected.

### Counterexamples

#### MOV example

```asm
49 8B 04 25 00 00 05 00
```

Expected behavior:

```asm
mov rax, qword ptr [0x50000]
```

Incorrect behavior in the current implementation:

```asm
mov rax, qword ptr [r13]
```

under conditions where the buggy path treats the no-base encoding as base-extended by `REX.B`.

#### LEA example

```asm
49 8D 04 25 00 00 05 00
```

Expected behavior:

```asm
lea rax, [0x50000]
```

Incorrect behavior in the current implementation:

```asm
lea rax, [r13]
```

### Fix

Update both sites so the SIB no-base decision is based only on:

- `mod == 0`
- `raw_base == 5`

and does not depend on `REX.B`.

## A simple demo to reproduce the current issue

```c++
static const uint8_t guest_code[] = {
    0x49, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x05, 0x00,    // mov rax, [0x50000] 
    0xC3,                                               // ret
};

static const uint8_t lea_guest_code[] = {
    0x49, 0x8D, 0x04, 0x25, 0x00, 0x00, 0x05, 0x00,    // lea rax, [0x50000]
    0xC3,                                               // ret
};
```

<img width="330" height="119" alt="image" src="https://github.com/user-attachments/assets/8fe67502-7053-4084-8bda-c2833f1e821b" />

Below is the complete POC to reproduce the issue:

```c++
// PoC: cpueaxh SIB "no-base" 特殊寻址模式 bug
//
// 文件: cpueaxh/cpu/helper.hpp  get_effective_offset()  第 280 行
//
// 问题: x86-64 有一个特殊编码规则 —— 当 SIB.base=101 且 ModRM.mod=00 时，
//       寻址模式是 [disp32]，不使用任何基址寄存器。这个规则不受 REX.B 影响。
//       但 emulator 错误地检查了 REX.B，导致这种情况被当成了"使用寄存器R13"。
//
// 测试方法: 在地址 0x50000 放 "dead"，在 R13 指向的 0x40000 放 "beef"。
//           执行同一条指令，真实CPU读到 "dead"，emulator 读到 "beef"。
//
// 构建: cl /EHsc /I cpueaxh poc_sib_r13.cpp /link /LIBPATH:x64\Debug

#define NOMINMAX
#include <windows.h>
#include <cstdio>
#include <cstdint>
#include <cstring>
#include "cpueaxh.hpp"

#pragma comment(lib, "cpueaxh.lib")

// ============================================================================
// 关键指令字节:  49 8B 04 25 00 00 05 00
//
//   字节   含义
//   ----   ----
//   49     REX prefix: W=1(64位操作), R=0, X=0, B=1
//   8B     opcode: MOV r64, r/m64
//   04     ModRM: mod=00, reg=000(RAX), rm=100(表示后面有SIB字节)
//   25     SIB:   scale=00, index=100(无索引), base=101(特殊编码)
//   00 00 05 00  disp32 = 0x00050000
//
// 根据 Intel SDM (Vol.2A, Table 2-3):
//   mod=00 + base=101 => 地址 = disp32 (不使用任何寄存器作为基址)
//   REX.B 在这种情况下被忽略，不会把 base 变成 R13
//
// 所以这条指令的语义是:  MOV RAX, qword ptr [0x50000]
// ============================================================================

// 原生执行: 把干扰值放进R13，然后执行同样的指令，验证CPU不会读R13
static const uint8_t shellcode[] = {
    0x41, 0x55,                                         // push r13
    0x49, 0x89, 0xCD,                                   // mov r13, rcx  (rcx = 干扰地址)
    0x49, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x05, 0x00,    // mov rax, [0x50000]  <-- 关键指令
    0x41, 0x5D,                                         // pop r13
    0xC3,                                               // ret
};

// Guest 模式: 同一条关键指令 + RET
static const uint8_t guest_code[] = {
    0x49, 0x8B, 0x04, 0x25, 0x00, 0x00, 0x05, 0x00,    // mov rax, [0x50000]  <-- 关键指令
    0xC3,                                               // ret
};

// LEA 版本: 同样的 SIB no-base 编码, 但只计算地址, 不访问内存
static const uint8_t lea_shellcode[] = {
    0x41, 0x55,                                         // push r13
    0x49, 0x89, 0xCD,                                   // mov r13, rcx  (rcx = 干扰地址)
    0x49, 0x8D, 0x04, 0x25, 0x00, 0x00, 0x05, 0x00,    // lea rax, [0x50000]
    0x41, 0x5D,                                         // pop r13
    0xC3,                                               // ret
};

static const uint8_t lea_guest_code[] = {
    0x49, 0x8D, 0x04, 0x25, 0x00, 0x00, 0x05, 0x00,    // lea rax, [0x50000]
    0xC3,                                               // ret
};

int main() {
    printf("=== cpueaxh SIB no-base bug PoC ===\n\n");

    // ---- 在固定地址 0x50000 放标记值 "dead" (这是 disp32 指向的正确目标) ----
    uint8_t* target_page = (uint8_t*)VirtualAlloc(
        (void*)0x50000, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
    if (!target_page) {
        printf("VirtualAlloc(0x50000) failed: %lu\n", GetLastError());
        return 1;
    }
    memcpy(target_page, "dead\0\0\0\0", 8);

    // ---- 另一块内存放 "beef" (emulator 会错误地从这里读) ----
    uint8_t* decoy_page = (uint8_t*)VirtualAlloc(
        NULL, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
    if (!decoy_page) {
        printf("VirtualAlloc(decoy) failed\n");
        return 1;
    }
    memcpy(decoy_page, "beef\0\0\0\0", 8);

    // ==================== 真实 CPU 执行 ====================
    {
        void* code = VirtualAlloc(NULL, 0x1000,
            MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
        memcpy(code, shellcode, sizeof(shellcode));

        // 通过 rcx 把 decoy_page 地址传入，shellcode 会赋给 R13
        typedef uint64_t(__fastcall* fn_t)(void*);
        uint64_t rax = ((fn_t)code)(decoy_page);

        char buf[9] = {};
        memcpy(buf, &rax, 8);
        printf("[native]   %s\n", buf);

        VirtualFree(code, 0, MEM_RELEASE);
    }

    // ==================== cpueaxh 模拟执行 ====================
    {
        cpueaxh_engine* engine = NULL;
        cpueaxh_err err = cpueaxh_open(CPUEAXH_ARCH_X86, CPUEAXH_MODE_64, &engine);
        if (err != CPUEAXH_ERR_OK) { printf("cpueaxh_open: %d\n", err); return 1; }

        cpueaxh_set_memory_mode(engine, CPUEAXH_MEMORY_MODE_GUEST);

        // Guest 内存:
        //   0x10000  代码页
        //   0x40000  R13 指向这里，放 "beef" (bug 会从这读)
        //   0x50000  disp32 指向这里，放 "dead" (正确行为应该从这读)
        //   0x60000  栈
        cpueaxh_mem_map(engine, 0x10000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE | CPUEAXH_PROT_EXEC);
        cpueaxh_mem_map(engine, 0x40000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE);
        cpueaxh_mem_map(engine, 0x50000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE);
        cpueaxh_mem_map(engine, 0x60000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE);

        cpueaxh_mem_write(engine, 0x10000, guest_code, sizeof(guest_code));
        cpueaxh_mem_write(engine, 0x40000, (const uint8_t*)"beef\0\0\0\0", 8);
        cpueaxh_mem_write(engine, 0x50000, (const uint8_t*)"dead\0\0\0\0", 8);

        uint64_t val;
        val = 0x40000;         cpueaxh_reg_write(engine, CPUEAXH_X86_REG_R13, &val);
        val = 0x60000 + 0x800; cpueaxh_reg_write(engine, CPUEAXH_X86_REG_RSP, &val);

        err = cpueaxh_emu_start(engine, 0x10000, 0x10000 + sizeof(guest_code) - 1, 0, 10);
        if (err != CPUEAXH_ERR_OK) {
            printf("cpueaxh_emu_start error: %d\n", err);
        }

        uint64_t rax = 0;
        cpueaxh_reg_read(engine, CPUEAXH_X86_REG_RAX, &rax);

        char buf[9] = {};
        memcpy(buf, &rax, 8);
        printf("[emulated] %s\n", buf);

        cpueaxh_close(engine);
    }

    // ==================== LEA 真实 CPU 执行 ====================
    {
        void* code = VirtualAlloc(NULL, 0x1000,
            MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
        memcpy(code, lea_shellcode, sizeof(lea_shellcode));

        typedef uint64_t(__fastcall* fn_t)(void*);
        uint64_t rax = ((fn_t)code)(decoy_page);
        printf("[native lea]   0x%llx\n", (unsigned long long)rax);

        VirtualFree(code, 0, MEM_RELEASE);
    }

    // ==================== LEA cpueaxh 模拟执行 ====================
    {
        cpueaxh_engine* engine = NULL;
        cpueaxh_err err = cpueaxh_open(CPUEAXH_ARCH_X86, CPUEAXH_MODE_64, &engine);
        if (err != CPUEAXH_ERR_OK) { printf("cpueaxh_open: %d\n", err); return 1; }

        cpueaxh_set_memory_mode(engine, CPUEAXH_MEMORY_MODE_GUEST);

        cpueaxh_mem_map(engine, 0x10000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE | CPUEAXH_PROT_EXEC);
        cpueaxh_mem_map(engine, 0x40000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE);
        cpueaxh_mem_map(engine, 0x60000, 0x1000, CPUEAXH_PROT_READ | CPUEAXH_PROT_WRITE);

        cpueaxh_mem_write(engine, 0x10000, lea_guest_code, sizeof(lea_guest_code));

        uint64_t val;
        val = 0x40000;         cpueaxh_reg_write(engine, CPUEAXH_X86_REG_R13, &val);
        val = 0x60000 + 0x800; cpueaxh_reg_write(engine, CPUEAXH_X86_REG_RSP, &val);

        err = cpueaxh_emu_start(engine, 0x10000, 0x10000 + sizeof(lea_guest_code) - 1, 0, 10);
        if (err != CPUEAXH_ERR_OK) {
            printf("cpueaxh_emu_start error: %d\n", err);
        }

        uint64_t rax = 0;
        cpueaxh_reg_read(engine, CPUEAXH_X86_REG_RAX, &rax);
        printf("[emulated lea] 0x%llx\n", (unsigned long long)rax);

        cpueaxh_close(engine);
    }

    // ==================== 判定 ====================
    printf("\n");
    printf("正确结果: 两行都应该是 \"dead\" (从 disp32=0x50000 读取)\n");
    printf("Bug 表现: emulated 行显示 \"beef\" (错误地从 R13=0x40000 读取)\n");
    printf("LEA 正确结果: 两行都应该是 0x50000\n");
    printf("LEA Bug 表现: emulated lea 显示 0x40000 (错误地把 R13 当成基址)\n");

    VirtualFree(target_page, 0, MEM_RELEASE);
    VirtualFree(decoy_page, 0, MEM_RELEASE);
    return 0;
}
```

I have tested the changes, and this issue is resolved after applying this PR.
<img width="337" height="128" alt="image" src="https://github.com/user-attachments/assets/27d4ee92-6df3-475a-b1f6-2cdb71381723" />
